### PR TITLE
Fix issue with util._extend deprecation in @ladjs/consolidate

### DIFF
--- a/lib/consolidate.js
+++ b/lib/consolidate.js
@@ -180,7 +180,7 @@ function fromStringRenderer(name) {
 
     return promisify(cb, function (cb) {
       readPartials(path, options, function (err, partials) {
-        const extend = requires.extend || (requires.extend = util._extend);
+        const extend = requires.extend || (requires.extend = Object.assign);
         const opts = extend({}, options);
         opts.partials = partials;
         if (err) return cb(err);
@@ -1363,7 +1363,7 @@ exports.dot.render = function (str, options, cb) {
   return promisify(cb, function (cb) {
     try {
       const engine = requires.dot || (requires.dot = require('dot'));
-      const extend = requires.extend || (requires.extend = util._extend);
+      const extend = requires.extend || (requires.extend = Object.assign);
       let settings = {};
       settings = extend(settings, engine.templateSettings);
       settings = extend(settings, options ? options.dot : {});
@@ -1421,7 +1421,7 @@ exports.ractive.render = function (str, options, cb) {
       options.template = template;
 
       if (options.data === null || options.data === undefined) {
-        const extend = requires.extend || (requires.extend = util._extend);
+        const extend = requires.extend || (requires.extend = Object.assign);
 
         // Shallow clone the options object
         options.data = extend({}, options);


### PR DESCRIPTION
### Description

This PR addresses the deprecation warning related to the use of `util._extend()` in the `@ladjs/consolidate` package. The warning is as follows:

`(node:72911) [DEP0060] DeprecationWarning: The util._extend API is deprecated. Please use Object.assign() instead.`

#### Issue
The `util._extend` API is deprecated and has been exposed to the user land by accident. This API is no longer maintained and should be replaced with `Object.assign()` as per the Node.js documentation: [Node.js Deprecation Warnings](https://nodejs.org/api/util.html#util_extendtarget-source)

This issue is particularly problematic when using Node.js version 22, where the warning is prominently displayed, causing potential confusion and clutter in the logs.

### Changes Made

- Replaced all instances of `util._extend()` with `Object.assign()` in the codebase.
- Ensured that the new implementation is consistent with the previous functionality.

## Checklist

- [x] I have ensured my pull request is not behind the main or master branch of the original repository.
- [ ] I have rebased all commits where necessary so that reviewing this pull request can be done without having to merge it first.
- [x] I have written a commit message that passes commitlint linting.
- [ ] I have ensured that my code changes pass linting tests.
- [ ] I have ensured that my code changes pass unit tests.
- [x] I have described my pull request and the reasons for code changes along with context if necessary.
